### PR TITLE
Cherry-pick: Ensure NRPE checks are updated under config-change

### DIFF
--- a/hooks/rabbitmq_server_relations.py
+++ b/hooks/rabbitmq_server_relations.py
@@ -787,12 +787,6 @@ def config_changed():
     rabbit.ConfigRenderer(
         rabbit.CONFIG_FILES).write_all()
 
-    # Only set values if this is the leader
-    if not is_leader():
-        return
-
-    rabbit.set_all_mirroring_queues(config('mirroring-queues'))
-
     if is_relation_made("ha"):
         ha_is_active_active = config("ha-vip-only")
 
@@ -806,6 +800,12 @@ def config_changed():
                     " skipping update nrpe checks")
     else:
         update_nrpe_checks()
+
+    # Only set values if this is the leader
+    if not is_leader():
+        return
+
+    rabbit.set_all_mirroring_queues(config('mirroring-queues'))
 
     # Update cluster in case min-cluster-size has changed
     for rid in relation_ids('cluster'):


### PR DESCRIPTION
Reorder the config-changed hook to ensure that NRPE checks are
updated across all units, not just the lead unit, when charm
options are changed by an operator.

Change-Id: Ia75471ea9781ecee115a837db89a6d597e82d512
Closes-Bug: 1790544